### PR TITLE
Use placeholder

### DIFF
--- a/menu-api/blueprints/restaurants/controllers/restaurant_resource.py
+++ b/menu-api/blueprints/restaurants/controllers/restaurant_resource.py
@@ -338,7 +338,7 @@ class GenerateSectionResource(RestaurantBaseResource):
     def get(self):
         if g.user is None:
             return FORBIDDEN
-        section = Section(_id=uuid.uuid4())
+        section = Section(_id=uuid.uuid4(), name="New section")
         return section
 
 
@@ -350,7 +350,7 @@ class GenerateItemResource(RestaurantBaseResource):
         if g.user is None:
             return FORBIDDEN
 
-        item = Item(_id=uuid.uuid4())
+        item = Item(_id=uuid.uuid4(), name="New item")
         return item
 
 

--- a/menu-api/blueprints/restaurants/documents/menuv2.py
+++ b/menu-api/blueprints/restaurants/documents/menuv2.py
@@ -41,7 +41,7 @@ class Item(EmbeddedDocument):
     image url of this menu item
     """
 
-    name = StringField(required=True, default="No name")
+    name = StringField(required=True, default="")
     """
     name of this menu item
     """
@@ -80,7 +80,7 @@ class Section(EmbeddedDocument):
     unique id of section object
     """
 
-    name = StringField(required=True, default="New Section")
+    name = StringField(required=True, default="")
     """
     name of this section
     """

--- a/menu-app/src/app/control-panel/collapsed-section/collapsed-section.component.scss
+++ b/menu-app/src/app/control-panel/collapsed-section/collapsed-section.component.scss
@@ -12,7 +12,6 @@
 
 ::ng-deep {
    .section-title .ql-editor {
-        display: inline-block;
         font-size: 30px;
         font-weight: 600;
         color: black;

--- a/menu-app/src/app/control-panel/collapsed-section/collapsed-section.component.ts
+++ b/menu-app/src/app/control-panel/collapsed-section/collapsed-section.component.ts
@@ -36,9 +36,6 @@ export class CollapsedSectionComponent implements OnInit {
 
   edit(): void {
     this.editMode = !this.editMode;
-    if (!this.section.name) {
-      this.section.name = 'Edit sections...';
-    }
     this.sectionOriginal = this.parse(this.section);
   }
 


### PR DESCRIPTION
Currently placeholders did not show and thus forced the text "edit sections..." as a placeholder. Fixed in this PR, also set defaults to empty string bc if user set title to empty, when reload user will see the default (new section for sections and no name for items) instead of empty.